### PR TITLE
Custom degree sorting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -41,10 +41,12 @@ if ( ! function_exists( 'ucf_degree_external_list_card_order' ) ) {
 			}
 		}
 
+		ksort( $colleges );
+
 		$retval->types = array_values( $colleges );
 
 		return $retval;
 	}
 
-	add_filter( 'ucf_degree_external_list_sort_cards', 'ucf_degree_external_list_card_order', 10, 3);
+	add_filter( 'ucf_degree_external_list_sort_colleges', 'ucf_degree_external_list_card_order', 10, 3);
 }

--- a/functions.php
+++ b/functions.php
@@ -4,4 +4,47 @@ include_once 'includes/config.php';
 include_once 'includes/template-twocol-functions.php';
 
 // Plugin extras/overrides
-// ...
+if ( ! function_exists( 'ucf_degree_external_list_card_order' ) ) {
+	/**
+	 * Overrides the sorting of the degrees
+	 *
+	 * @param Object $items The decoded JSON of degree data
+	 * @param string $layout The layout currently being used
+	 * @param array $args Any additional arguments passed in from the shortcode
+	 */
+	function ucf_degree_external_list_card_order( $items, $layout, $args ) {
+		$retval = clone $items;
+		$retval->types = array();
+		$colleges = array();
+
+		foreach( $items->types as $type ) {
+			$current_type = $type->alias;
+
+			foreach( $type->degrees as $degree ) {
+				foreach( $degree->colleges as $college ) {
+					$degree->type = $current_type;
+
+					if ( ! isset( $colleges[$college->slug] ) ) {
+						$colleges[$college->slug] = (object)array(
+							'alias'  => $college->name,
+							'slug'  => $college->slug,
+							'count' => 1,
+							'degrees' => array(
+								$degree
+							)
+						);
+					} else {
+						$colleges[$college->slug]->degrees[] = $degree;
+						$colleges[$college->slug]->count++;
+					}
+				}
+			}
+		}
+
+		$retval->types = array_values( $colleges );
+
+		return $retval;
+	}
+
+	add_filter( 'ucf_degree_external_list_sort_cards', 'ucf_degree_external_list_card_order', 10, 3);
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Admissions-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Admissions-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a filter for sorting degree results from the main site API by college instead of by program_type.

**Motivation and Context**
The default sorting field for degrees coming from the `/ucf-degree-search/v1/degrees/` endpoint is by `program_type`. This groups the degrees by college.

**How Has This Been Tested?**
This has been tested on the `/academics/` page of the Undergraduate Admissions DEV site.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.**

** A small section letting users know of the existence of this `sort_by` type will need to be made. This will help them understand the difference between the default sorting and the `colleges` sort by parameter.
