### PR TITLE
Updated to route users back to topic lists from FAQ single pages

### DIFF
--- a/single-faq.php
+++ b/single-faq.php
@@ -22,6 +22,11 @@ $related_faq_title = ( get_field( 'related-faq-title', $topic ) ) ? get_field( '
 $cta_text = get_field( 'faq-topic-footer-cta-text', $topic );
 $cta_url = site_url() . get_field( 'faq-topic-footer-cta-url', $topic );
 
+if ( $topic ) {
+	$cta_text = "View All $topic->name FAQs";
+	$cta_url  = get_term_link( $topic, 'topic' );
+}
+
 $tags = wp_get_post_tags( $post->ID, array( 'fields' => 'slugs' ) );
 $related_posts = UCF_FAQ_Common::get_related_faqs_by_tag( $tags, array( $post->ID ) );
 ?>
@@ -37,7 +42,7 @@ $related_posts = UCF_FAQ_Common::get_related_faqs_by_tag( $tags, array( $post->I
 			<?php endif; ?>
 			<?php if ( $cta_text && $cta_url ) : ?>
 				<div class="ucf-faq-footer">
-					<?php echo UCF_FAQ_Common::display_footer_cta( $cta_text, $cta_url ); ?>
+					<a href="<?php echo $cta_url; ?>" class="btn btn-outline-secondary mt-4"><?php echo $cta_text; ?></a>
 				</div>
 			<?php endif; ?>
 		</article>

--- a/single-faq.php
+++ b/single-faq.php
@@ -19,9 +19,6 @@ if ( $topic && is_array( $topic ) ) {
 
 $related_faq_title = ( get_field( 'related-faq-title', $topic ) ) ? get_field( 'related-faq-title', $topic ) : 'Related FAQs';
 
-$cta_text = get_field( 'faq-topic-footer-cta-text', $topic );
-$cta_url = site_url() . get_field( 'faq-topic-footer-cta-url', $topic );
-
 if ( $topic ) {
 	$cta_text = "View All $topic->name FAQs";
 	$cta_url  = get_term_link( $topic, 'topic' );


### PR DESCRIPTION
<!---
Thank you for contributing to Admissions-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Admissions-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added logic to add a link back to the primary topic FAQ list page on each FAQ single page.

**Motivation and Context**
We want users who organically get to the FAQ pages to be able to get back to the primary topic's FAQ list page instead of being taken all the way back to the topic list page.

**How Has This Been Tested?**
Changes are available in dev for review.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
