### PR TITLE
JSON+LD Schema for FAQ Pages

### DIFF
--- a/single-faq.php
+++ b/single-faq.php
@@ -58,7 +58,11 @@ $generate = UCF_FAQ_Config::get_option_or_default( 'add_json_data' );
 
 if ( $generate ) : ?>
 <script type="application/ld+json">
-	<?php echo UCF_FAQ_Common::generate_json_ld( array( $post ) ); ?>
+<?php
+	if ( method_exists( UCF_FAQ_Common, 'generate_json_ld' ) ) {
+		echo UCF_FAQ_Common::generate_json_ld( array( $post ) );
+	}
+?>
 </script>
 <?php endif; ?>
 <?php get_footer(); ?>

--- a/single-faq.php
+++ b/single-faq.php
@@ -53,4 +53,12 @@ $related_posts = UCF_FAQ_Common::get_related_faqs_by_tag( $tags, array( $post->I
 		<?php endif; ?>
 	</div>
 </div>
+<?php
+$generate = UCF_FAQ_Config::get_option_or_default( 'add_json_data' );
+
+if ( $generate ) : ?>
+<script type="application/ld+json">
+	<?php echo UCF_FAQ_Common::generate_json_ld( array( $post ) ); ?>
+</script>
+<?php endif; ?>
 <?php get_footer(); ?>

--- a/single-faq.php
+++ b/single-faq.php
@@ -59,7 +59,7 @@ $generate = UCF_FAQ_Config::get_option_or_default( 'add_json_data' );
 if ( $generate ) : ?>
 <script type="application/ld+json">
 <?php
-	if ( method_exists( UCF_FAQ_Common, 'generate_json_ld' ) ) {
+	if ( method_exists( 'UCF_FAQ_Common', 'generate_json_ld' ) ) {
 		echo UCF_FAQ_Common::generate_json_ld( array( $post ) );
 	}
 ?>


### PR DESCRIPTION
<!---
Thank you for contributing to Admissions-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Admissions-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds logic to the theme that takes advantage of the JSON+LD generation logic in the UCF_FAQ_CPT plugin.

**Motivation and Context**
Allows for the JSON+LD data to be written beneath the FAQ on a single FAQ page.

**How Has This Been Tested?**
Changes have been tested locally both with the up to date UCF_FAQ_CPT plugin and with an older version of the plugin (ensuring it fails gracefully if the `generate_json_ld` function doesn't exist).

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
